### PR TITLE
Fixed a typo in workflow name

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Generate REAME.md File
+name: Generate README.md File
 
 on:
   push:


### PR DESCRIPTION
Before: `name: Generate REAME.md File`

After: `name: Generate README.md File`